### PR TITLE
Fix HTTP_X_FORWARDED_FOR header retrieval

### DIFF
--- a/Plugin/SkipTwoFactorAuthPlugin.php
+++ b/Plugin/SkipTwoFactorAuthPlugin.php
@@ -99,8 +99,8 @@ class SkipTwoFactorAuthPlugin
             return $server['HTTP_CF_CONNECTING_IP'];
         } elseif (isset($key) && isset($server[(string)$key])) {
             return $server[(string)$key];
-        } elseif (isset($server['HTTP_X_FORWARDED_FOR'])) {
-            return $server['HTTP_X_FORWARDED_FOR'][0];
+        } elseif (isset($server['HTTP_X_FORWARDED_FOR']) && !empty($server['HTTP_X_FORWARDED_FOR'])) {
+            return explode(',', $server['HTTP_X_FORWARDED_FOR'])[0];
         } else {
             return $this->remoteAddress->getRemoteAddress();
         }


### PR DESCRIPTION
HTTP_X_FORWARDED_FOR gives a comma separated list of IP addresses, the first one being the client's actual IP address. This splits that list of IP addresses so the first one can be compared to the list of allowed IP addresses.